### PR TITLE
[RFCT] Use a counter variable for readability.

### DIFF
--- a/ft_bzero.c
+++ b/ft_bzero.c
@@ -6,7 +6,7 @@
 /*   By: akyoshid <akyoshid@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/16 11:21:05 by akyoshid          #+#    #+#             */
-/*   Updated: 2023/11/16 11:28:04 by akyoshid         ###   ########.fr       */
+/*   Updated: 2023/11/16 11:41:18 by akyoshid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,14 @@
 void	ft_bzero(void *s, size_t n)
 {
 	unsigned char	*ptr;
+	size_t			i;
 
 	ptr = (unsigned char *)s;
-	while (n > 0)
+	i = 0;
+	while (i < n)
 	{
-		*ptr = 0;
-		ptr++;
-		n--;
+		ptr[i] = 0;
+		i++;
 	}
 }
 

--- a/ft_memset.c
+++ b/ft_memset.c
@@ -6,7 +6,7 @@
 /*   By: akyoshid <akyoshid@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/16 11:00:53 by akyoshid          #+#    #+#             */
-/*   Updated: 2023/11/16 11:18:55 by akyoshid         ###   ########.fr       */
+/*   Updated: 2023/11/16 11:39:32 by akyoshid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,14 +27,27 @@ void	*ft_memset(void *b, int c, size_t len)
 {
 	unsigned char	*ptr;
 	unsigned char	ch;
+	size_t			i;
 
 	ptr = (unsigned char *)b;
 	ch = (unsigned char)c;
-	while (len > 0)
+	i = 0;
+	while (i < len)
 	{
-		*ptr = c;
-		ptr++;
-		len--;
+		ptr[i] = c;
+		i++;
 	}
 	return (b);
 }
+
+// int	main(void)
+// {
+// 	unsigned char	str1[11] = "0123456789";
+// 	unsigned char	str2[11] = "0123456789";
+
+// 	ft_memset(str1, 256 + 'a', 5);
+// 	memset(str2, 256 + 'a', 5);
+// 	printf("%s\n", str1);
+// 	printf("%s\n", str2);
+// 	return (0);
+// }


### PR DESCRIPTION
## Refactoring
Changed to use a counter variable to improve readability.

Initially, I didn't use a counter variable because I thought there might be an issue when manipulating memory with a length that couldn't be held by a `size_t` type counter variable. However, I later realized that there would be no problem even if a `size_t` type counter variable was used, as only the number passed as a `size_t` type argument is manipulated.