### PR TITLE
Write ft_strmapi

### DIFF
--- a/ft_strmapi.c
+++ b/ft_strmapi.c
@@ -6,7 +6,7 @@
 /*   By: akyoshid <akyoshid@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/21 19:09:51 by akyoshid          #+#    #+#             */
-/*   Updated: 2023/11/21 19:34:16 by akyoshid         ###   ########.fr       */
+/*   Updated: 2023/11/21 19:57:44 by akyoshid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,16 +15,19 @@
 // and passing its index as first argument
 // to create a new string resulting from successive applications of ’f’
 
+// === RETURN VALUE ===
+// if (s == NULL || f == NULL) → Return NULL.
+
 #include "libft.h"
 
 char	*ft_strmapi(char const *s, char (*f)(unsigned int, char))
 {
 	char	*buff;
-	size_t	s_len;
 	size_t	i;
 
-	s_len = ft_strlen(s);
-	buff = malloc((s_len + 1) * sizeof(char));
+	if (s == NULL || f == NULL)
+		return (NULL);
+	buff = malloc((ft_strlen(s) + 1) * sizeof(char));
 	if (buff == NULL)
 		return (NULL);
 	i = 0;
@@ -33,16 +36,24 @@ char	*ft_strmapi(char const *s, char (*f)(unsigned int, char))
 		buff[i] = (*f)((unsigned int)i, s[i]);
 		i++;
 	}
+	buff[i] = '\0';
 	return (buff);
 }
 
-char	ft_addindex(unsigned int i, char c)
-{
-	return ((char)i + c);
-}
+// char	ft_addindex(unsigned int i, char c)
+// {
+// 	return ((char)i + c);
+// }
 
-int	main(void)
-{
-	printf("%s\n", ft_strmapi("00000", *ft_addindex));
-	return (0);
-}
+// int	main(void)
+// {
+// 	char	str[] = "00000";
+// 	// char	*str = NULL;
+// 	char	*ptr;
+
+// 	ptr = ft_strmapi(str, ft_addindex);
+// 	printf("Before ft_strmapi: %s\n", str);
+// 	printf("Before ft_strmapi: %s\n", ptr);
+// 	free(ptr);
+// 	return (0);
+// }

--- a/ft_strmapi.c
+++ b/ft_strmapi.c
@@ -1,0 +1,48 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strmapi.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: akyoshid <akyoshid@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/11/21 19:09:51 by akyoshid          #+#    #+#             */
+/*   Updated: 2023/11/21 19:34:16 by akyoshid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+// === DESCRIPTION ===
+// Applies the function ’f’ to each character of the string ’s’,
+// and passing its index as first argument
+// to create a new string resulting from successive applications of ’f’
+
+#include "libft.h"
+
+char	*ft_strmapi(char const *s, char (*f)(unsigned int, char))
+{
+	char	*buff;
+	size_t	s_len;
+	size_t	i;
+
+	s_len = ft_strlen(s);
+	buff = malloc((s_len + 1) * sizeof(char));
+	if (buff == NULL)
+		return (NULL);
+	i = 0;
+	while (s[i] != '\0')
+	{
+		buff[i] = (*f)((unsigned int)i, s[i]);
+		i++;
+	}
+	return (buff);
+}
+
+char	ft_addindex(unsigned int i, char c)
+{
+	return ((char)i + c);
+}
+
+int	main(void)
+{
+	printf("%s\n", ft_strmapi("00000", *ft_addindex));
+	return (0);
+}


### PR DESCRIPTION
(ft_addindex == *ft_addindex) is TRUE.
However, it is customary not to use dereference (*) when passing a function pointer as an argument.